### PR TITLE
Issue #70 fix.

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -72,7 +72,7 @@ else version(IntegrationTest1)
         auto logger = new shared StrictLogger(logName);
         scope(exit) logger.finalize();
         
-        auto api = new shared PostgreSQL();
+        auto api = new shared PostgreSQL(logger);
         logger.logInfo("PostgreSQL was inited.");
         auto connProvider = new shared PQConnProvider(logger, api);
         
@@ -130,7 +130,7 @@ else version(IntegrationTest2)
         auto logger = new shared StrictLogger(logName);
         scope(exit) logger.finalize();
         
-        auto api = new shared PostgreSQL();
+        auto api = new shared PostgreSQL(logger);
         logger.logInfo("PostgreSQL was inited.");
         auto connProvider = new shared PQConnProvider(logger, api);
         

--- a/source/db/async/pool.d
+++ b/source/db/async/pool.d
@@ -178,9 +178,6 @@ class AsyncPool : IConnectionPool
             argnums = 0u.repeat.take(commands.length).array;
         }
         
-        logger.logInfo(text("Posting transaction: ", commands, ", params: ", params
-                , ", argnums: ", argnums, ", vars: ", vars));
-        
         auto conn = fetchFreeConnection();
         auto transaction = new immutable Transaction(commands, params, argnums, vars);
         processingTransactions.insert(cast(shared)transaction); 
@@ -233,7 +230,7 @@ class AsyncPool : IConnectionPool
         
         if(processingTransactions[].find(cast(shared)transaction).empty)
             throw new UnknownTransactionException();
-             
+                
         if(transaction in awaitingResponds) 
         {
             processingTransactions.removeOne(cast(shared)transaction);
@@ -242,6 +239,10 @@ class AsyncPool : IConnectionPool
             awaitingResponds.remove(transaction);
             if(respond.failed)
             {
+                auto tr = cast(Transaction)transaction;
+                assert(tr);      
+                logger.logInfo(text("Transaction fail: ", tr.commands, ", params: ", tr.params
+                    , ", argnums: ", tr.argnums, ", vars: ", tr.vars));
                 throw new QueryProcessingException(respond.exception);
             }
             else

--- a/source/db/pq/api.d
+++ b/source/db/pq/api.d
@@ -19,6 +19,7 @@ public import db.pq.types.oids;
 import db.connection;
 import db.pq.types.conv;
 import vibe.data.bson;
+import dlogg.log;
 
 /**
 *   All exceptions thrown by postgres api is inherited from this exception.
@@ -184,7 +185,7 @@ interface IPGresult
             Bson[] rows;
             foreach(j; 0..ntuples)
             {
-                rows ~= pqToBson(ftype(i), asBytes(j, i), conn);
+                rows ~= pqToBson(ftype(i), asBytes(j, i), conn, logger);
             }
             fields[fname(i)] = Bson(rows);
         }
@@ -209,7 +210,7 @@ interface IPGresult
     		
     		foreach(j; 0..nfields)
     		{
-    			entry[fname(j)] = pqToBson(ftype(j), asBytes(i, j), conn);	
+    			entry[fname(j)] = pqToBson(ftype(j), asBytes(i, j), conn, logger);	
     		}
     		
     		arr ~= Bson(entry);
@@ -218,6 +219,9 @@ interface IPGresult
     	return Bson(arr);
     	
     }
+    
+    /// Getting local logger
+    protected shared(ILogger) logger() nothrow;
 }
 
 /**
@@ -344,6 +348,9 @@ interface IPGconn
     *   Throws: PGParamNotExistException
     */
     string parameterStatus(string param) const;
+    
+    /// Getting local logger
+    protected shared(ILogger) logger() nothrow;
 }
 
 /**
@@ -376,5 +383,8 @@ shared interface IPostgreSQL
         *   loads library in memory.
         */
         void initialize();
+        
+        /// Getting local logger
+        shared(ILogger) logger() nothrow;
     }
 }

--- a/source/server/database.d
+++ b/source/server/database.d
@@ -266,7 +266,7 @@ shared class Database
 			reTime = timeout;
 		}
 
-		api = new shared PostgreSQL();
+		api = new shared PostgreSQL(logger);
 		auto provider = new shared PQConnProvider(logger, api);
 		
 		pool = new shared AsyncPool(logger, provider, reTime, timeout, aliveCheckTime);


### PR DESCRIPTION
Детали реализации:
- Логгер пробрасывается в обертки для работы с базой
- Обнаруживаются падения конвертации байтов из базы в bson, payload также логируется
- При критическом падении внутренного quering worker, транзакция-виновница логируется (полностью)
- Транзакция логируется на верхнем уровне, если снизу пришло исключение (обычно это SQL исключения)
