### PR TITLE
Issue 68

### DIFF
--- a/source/server/config.d
+++ b/source/server/config.d
@@ -61,10 +61,10 @@ struct AppConfig
 	int sqlReconnectTime = -1; //ms
 	
 	@possible
-	int groupid = -1; // to low root privileges
+	string groupid; // to low root privileges
 	
 	@possible
-	int userid = -1; // to low root privileges
+	string userid; // to low root privileges
 	
 	@required
 	string vibelog = "/var/log/"~APPNAME~"/"~"http.txt";

--- a/source/util.d
+++ b/source/util.d
@@ -994,3 +994,36 @@ unittest
             }
             ).generator.equal(a.repeat.take(10)));
 }
+
+private template TypesOf(T...)
+{
+    static if(T.length == 1)
+        alias TypesOf = typeof(T[0]);
+    else
+        alias TypesOf = TypeTuple!(typeof(T[0]), TypesOf!(T[1..$]));
+}
+
+/**
+*   Allows to fast retreiving results from functions that returns a tuple.
+*/
+@property void tie(T...)(Tuple!(TypesOf!T) t)
+{
+    foreach(i, ref var; T)
+    {
+        T[i] = t[i];
+    }
+}
+/// Example
+unittest
+{
+    Tuple!(int, string) foo()
+    {
+        return tuple(1, "a");
+    }
+    
+    int x;
+    string y;
+    
+    tie!(x,y) = foo();
+    assert(x == 1 && y == "a");
+}


### PR DESCRIPTION
Closing #68. Now able to specify `userid` and `groupid` as names in the config. Also old way (directly pass ints) is still operational.
