### PR TITLE
This patch simplifies .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: d
 
+d: dmd-2.066.1
+
 addons:
-  postgresql: 9.3
+  postgresql: 9.4
 
 services: postgresql
 
@@ -9,21 +11,6 @@ before_script:
   - psql -c 'create database "pgator-test";' -U postgres
   - psql --dbname="pgator-test" -f .travis-json_rpc.sql -U postgres
 
-install:
-  # dmd
-  # dub
-  - DMD_VER=2.066.0
-  - DMD=dmd_${DMD_VER}-0_amd64.deb
-  - DUB_VER=0.9.22
-  - DUB=dub-${DUB_VER}-linux-x86_64
-  - wget http://downloads.dlang.org/releases/2014/${DMD}
-  - sudo dpkg -i ${DMD} || true
-  - sudo apt-get -y update
-  - sudo apt-get -fy install
-  - sudo dpkg -i ${DMD}
-  - wget http://code.dlang.org/files/${DUB}.tar.gz
-  - sudo tar -C /usr/local/bin -zxf ${DUB}.tar.gz
-  
 script:
   # compilation test for production
   - dub test


### PR DESCRIPTION
Travis-ci.org now supports dlang natively This patch simplifies .travis.yml
